### PR TITLE
Fix: Use `~` operator to limit compatibility with PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "source": "https://github.com/ergebnis/day-one-to-obsidian-converter"
   },
   "require": {
-    "php": "^8.1",
+    "php": "~8.1.0 || ~8.2.0",
     "ergebnis/json-schema-validator": "^2.0.0",
     "symfony/console": "^6.2.1",
     "symfony/filesystem": "^6.1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ed84a60ef61e26112d4fbddcafdece6",
+    "content-hash": "c0cb5f3dd6da5cdbda444de6d340d740",
     "packages": [
         {
             "name": "ergebnis/json-schema-validator",
@@ -6017,7 +6017,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "~8.1.0 || ~8.2.0"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
This pull request

- [x] uses the `~` operator to limit the compatibility with PHP versions 

Follows https://github.com/ergebnis/php-package-template/pull/1086.